### PR TITLE
Make warmup a function of time rather than a number of iterations.

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -54,7 +54,28 @@ def read_queries(query_path):
         c = json.loads(q)
         yield Query(c["query"], c["tags"])
 
-WARMUP_ITER = 1800
+# Print progress, borrowed from https://stackoverflow.com/questions/3173320/text-progress-bar-in-terminal-with-block-characters
+def printProgressBar (progress, prefix = '', suffix = '', decimals = 1, length = 100, fill = '█', printEnd = "\r"):
+    """
+    Call in a loop to create terminal progress bar
+    @params:
+        progress    - Required  : current progress in [0,1] (Float)
+        prefix      - Optional  : prefix string (Str)
+        suffix      - Optional  : suffix string (Str)
+        decimals    - Optional  : positive number of decimals in percent complete (Int)
+        length      - Optional  : character length of bar (Int)
+        fill        - Optional  : bar fill character (Str)
+        printEnd    - Optional  : end character (e.g. "\r", "\r\n") (Str)
+    """
+    percent = ("{0:." + str(decimals) + "f}").format(100 * progress)
+    filledLength = int(length * progress)
+    bar = fill * filledLength + '-' * (length - filledLength)
+    print(f'\r{prefix} |{bar}| {percent}% {suffix}', end = printEnd)
+    # Print New Line on Complete
+    if progress >= 1:
+        print()
+
+WARMUP_TIME = 10 * 60 # 10 minutes
 NUM_ITER = 10
 
 if __name__ == "__main__":
@@ -81,22 +102,27 @@ if __name__ == "__main__":
             print("======================")
             print("BENCHMARKING %s %s" % (engine, command))
             search_client = SearchClient(engine)
-            print("--- Warming up ...")
             queries_shuffled = list(queries[:])
             random.seed(2)
             random.shuffle(queries_shuffled)
-            for i in range(WARMUP_ITER):
-                print(i)
+            warmup_start = time.monotonic()
+            printProgressBar(0, prefix = 'Warmup:', suffix = 'Complete', length = 50)
+            while True:
                 for _ in drive(queries_shuffled, search_client, command):
                     pass
+                progress = min(1, (time.monotonic() - warmup_start) / WARMUP_TIME)
+                printProgressBar(progress, prefix = 'Warmup:', suffix = 'Complete', length = 50)
+                if progress == 1:
+                    break
+            printProgressBar(0, prefix = 'Run:   ', suffix = 'Complete', length = 50)
             for i in range(NUM_ITER):
-                print("- Run #%s of %s" % (i + 1, NUM_ITER))
                 for (query, count, duration) in drive(queries_shuffled, search_client, command):
                     if count is None:
                         query_idx[query.query] = {count: -1, duration: []}
                     else:
                         query_idx[query.query]["count"] = count
                         query_idx[query.query]["duration"].append(duration)
+                printProgressBar(float(i + 1) / NUM_ITER, prefix = 'Run:   ', suffix = 'Complete', length = 50)
             for query in engine_results:
                 query["duration"].sort()
             results_commands[engine] = engine_results


### PR DESCRIPTION
This changes warmup from a number of iterations to an amount of time waiting for the engine to warm up. This should help keep warmup times contained with slow engines and/or commands while still providing enough warmup time to engines in most cases.

This also switches to a progress bar, as printing each iteration number on a new line could exhaust my shell window's history, making it challenging to check the overall progress of the benchmark.