### PR TITLE
Add TOP_100 and TOP_1000 commands.

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -28,8 +28,8 @@ The command describes the type of operation that should
 be performed. Right now there are three commands
 
 - `COUNT` Outputs the document count.
-- `TOP10` computes the top-K elements. Just outputs "1"
-- `TOP10_COUNT` computes the topK documents and the overall count of matching documents. Outputs the document count.
+- `TOP_10`, `TOP_100` and `TOP_1000` compute the top-K elements and output "1"
+- `TOP_10_COUNT`, `TOP_100_COUNT` and `TOP_1000_COUNT` compute the top-K documents and the overall count of matching documents, and output the document count.
 
 Scores for these commands should be as close as possible to lucene's BM25.
 If BM25  is not available, fall back to TfIdf. If TfIdf is not available,

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,12 @@ export
 
 WIKI_SRC = "https://www.dropbox.com/s/wwnfnu441w1ec9p/wiki-articles.json.bz2"
 
-# COMMANDS ?=  TOP_10 TOP_10_COUNT TOP_100_COUNT TOP_1000_COUNT UNOPTIMIZED_COUNT COUNT
-COMMANDS ?=  TOP_10 TOP_10_COUNT TOP_100_COUNT TOP_1000_COUNT COUNT
+COMMANDS ?=  TOP_100 TOP_100_COUNT COUNT
 
 # ENGINES ?= tantivy-0.13 lucene-8.4.0 pisa-0.8.2 rucene-0.1 bleve-0.8.0-scorch rucene-0.1 tantivy-0.11 tantivy-0.14 tantivy-0.15 tantivy-0.16 tantivy-0.17 tantivy-0.18 tantivy-0.19
 # ENGINES ?= tantivy-0.16 lucene-8.10.1 pisa-0.8.2 bleve-0.8.0-scorch bluge-0.2.2 rucene-0.1
 # ENGINES ?= tantivy-0.16 tantivy-0.17 tantivy-0.18 tantivy-0.19
-ENGINES ?= tantivy-0.20 tantivy-0.21 lucene-9.6.0 lucene-8.10.1
+ENGINES ?= tantivy-0.21 lucene-9.6.0 pisa-0.8.2
 PORT ?= 8080
 
 help:

--- a/engines/lucene-8.10.1/src/main/java/DoQuery.java
+++ b/engines/lucene-8.10.1/src/main/java/DoQuery.java
@@ -43,6 +43,18 @@ public class DoQuery {
                                 count = 1;
                             }
                             break;
+                        case "TOP_100":
+                            {
+                                final TopDocs topDocs = searcher.search(query, 100);
+                                count = 1;
+                            }
+                            break;
+                        case "TOP_1000":
+                            {
+                                final TopDocs topDocs = searcher.search(query, 1000);
+                                count = 1;
+                            }
+                            break;
                         case "TOP_10_COUNT":
                             {
                                 final TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(10, Integer.MAX_VALUE);

--- a/engines/lucene-9.6.0/src/main/java/DoQuery.java
+++ b/engines/lucene-9.6.0/src/main/java/DoQuery.java
@@ -43,6 +43,18 @@ public class DoQuery {
                                 count = 1;
                             }
                             break;
+                        case "TOP_100":
+                            {
+                                final TopDocs topDocs = searcher.search(query, 100);
+                                count = 1;
+                            }
+                            break;
+                        case "TOP_1000":
+                            {
+                                final TopDocs topDocs = searcher.search(query, 1000);
+                                count = 1;
+                            }
+                            break;
                         case "TOP_10_COUNT":
                             {
                                 final TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(10, Integer.MAX_VALUE);

--- a/engines/pisa-0.8.2/tools/do_query.cpp
+++ b/engines/pisa-0.8.2/tools/do_query.cpp
@@ -32,7 +32,6 @@ int main(int argc, char const* argv[])
     std::string index_filename = fmt::format("{}/{}.simdbp", IDX_DIR, INV);
 
     std::string scorer_name = "quantized";
-    size_t k = 10;
 
     auto term_processor = TermProcessor(terms_file, std::nullopt, std::nullopt);
     using wand_uniform_index_quantized = wand_data<wand_data_raw>;
@@ -91,7 +90,17 @@ int main(int argc, char const* argv[])
                 or_query<false> or_q;
                 count = or_q(make_cursors(index, query), index.num_docs());
             }
-        } else if (tokens[0] == "TOP_10") {
+        } else if (tokens[0] == "TOP_10" || tokens[0] == "TOP_100" || tokens[0] == "TOP_1000") {
+            size_t k;
+            if (tokens[0] == "TOP_10") {
+                k = 10;
+            } else if (tokens[0] == "TOP_100") {
+                k = 100;
+            } else if (tokens[0] == "TOP_1000") {
+                k = 1000;
+            } else {
+                throw std::runtime_error(fmt::format("Can't compute k for {}", tokens[0]));
+            }
             topk_queue topk(k);
             if (intersection or query.terms.size() == 1) {
                 ranked_and_query ranked_and_q(topk);
@@ -110,7 +119,7 @@ int main(int argc, char const* argv[])
                 topk.finalize();
                 count = 1;
             }
-        } else if (tokens[0] == "TOP_10_COUNT") {
+        } else if (tokens[0] == "TOP_10_COUNT" || tokens[0] == "TOP_100_COUNT" || tokens[0] == "TOP_1000_COUNT") {
             if (intersection or query.terms.size() == 1) {
                 scored_and_query and_q;
                 count = and_q(make_scored_cursors(index, *scorer, query), index.num_docs()).size();

--- a/engines/tantivy-0.20/src/bin/do_query.rs
+++ b/engines/tantivy-0.20/src/bin/do_query.rs
@@ -171,6 +171,14 @@ fn main_inner(index_dir: &Path) -> tantivy::Result<()> {
                 let _top_k = searcher.search(&query, &TopDocs::with_limit(10))?;
                 count = 1;
             }
+            "TOP_100" => {
+                let _top_k = searcher.search(&query, &TopDocs::with_limit(100))?;
+                count = 1;
+            }
+            "TOP_1000" => {
+                let _top_k = searcher.search(&query, &TopDocs::with_limit(1000))?;
+                count = 1;
+            }
             "TOP_1_COUNT" => {
                 let (_top_k, count_) = searcher.search(&query, &(TopDocs::with_limit(1), Count))?;
                 count = count_;

--- a/engines/tantivy-0.21/src/bin/do_query.rs
+++ b/engines/tantivy-0.21/src/bin/do_query.rs
@@ -171,6 +171,14 @@ fn main_inner(index_dir: &Path) -> tantivy::Result<()> {
                 let _top_k = searcher.search(&query, &TopDocs::with_limit(10))?;
                 count = 1;
             }
+            "TOP_100" => {
+                let _top_k = searcher.search(&query, &TopDocs::with_limit(100))?;
+                count = 1;
+            }
+            "TOP_1000" => {
+                let _top_k = searcher.search(&query, &TopDocs::with_limit(1000))?;
+                count = 1;
+            }
             "TOP_1_COUNT" => {
                 let (_top_k, count_) = searcher.search(&query, &(TopDocs::with_limit(1), Count))?;
                 count = count_;


### PR DESCRIPTION
These commands are interesting to me for two reasons:
 - It's common to retrieve more hits than the size of a page in the first stage in order to feed more data into rerankers.
 - WAND and variants are reputed to work better with low `k` values while MAXSCORE and variants are reputed to work better with higher `k` values, so it would be interesting to see if this holds in this benchmark.

I took the freedom to change the default commands from `TOP_10` / `TOP_10_COUNT` to `TOP_100` / `TOP_100_COUNT` in the `Makefile` because it felt more like a typical `k` value to me (Lucene changed to this value for its nightly benchmarks ~1 year ago). Happy to revert this bit if it's controversial.