### PR TITLE
Add `to be or not to be` query.

### DIFF
--- a/queries.txt
+++ b/queries.txt
@@ -897,3 +897,6 @@
 {"query": "\"laborers international union of north america\"", "tags": ["phrase", "phrase:num_tokens_>3"]}
 {"query": "laborers international union of north america", "tags": ["union", "global", "union:num_tokens_>3"]}
 {"query": "+\"the who\" +uk", "tags": ["two-phase-critic"]}
+{"query": "+to +be +or +not +to +be", "tags": ["intersection", "intersection:num_tokens_>3"]}
+{"query": "\"to be or not to be\"", "tags": ["phrase", "phrase:num_tokens_>3"]}
+{"query": "to be or not to be", "tags": ["union", "union:num_tokens_>3"]}


### PR DESCRIPTION
This is a classical example of why not to drop stopwords, because this query then can't be searched. But if stop words are not removed, this is an extremely expensive query. It would be interesting to see how the various engines deal with this query.

For reference, one trick that helps consists of first rewriting the query into `to^2 be^2 or not` in order to have fewer clauses to deal with.