### PR TITLE
Add disjunctive query with many many clauses.

### DIFF
--- a/queries.txt
+++ b/queries.txt
@@ -900,3 +900,4 @@
 {"query": "+to +be +or +not +to +be", "tags": ["intersection", "intersection:num_tokens_>3"]}
 {"query": "\"to be or not to be\"", "tags": ["phrase", "phrase:num_tokens_>3"]}
 {"query": "to be or not to be", "tags": ["union", "union:num_tokens_>3"]}
+{"query": "a search engine is an information retrieval software system designed to help find information stored on one or more computer systems", "tags": ["union", "union:num_tokens_>3"]}


### PR DESCRIPTION
This query is interesting because some implementation choices can make big differences, e.g.
 - reordering doc IDs across many clauses with a heap is slower than with a bit set,
 - if you're not being careful, implementations of block-max WAND or block-max MAXSCORE can easily spend more time reasoning about max scores per block than actually evaluating hits.

Lucene recently incorporated such queries to its benchmarking: https://github.com/mikemccand/luceneutil/pull/305.