### PR TITLE
Increase warmup time to 60s.

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -75,7 +75,7 @@ def printProgressBar (progress, prefix = '', suffix = '', decimals = 1, length =
     if progress >= 1:
         print()
 
-WARMUP_TIME = 1 # 1 seconds
+WARMUP_TIME = 60 # 60 seconds
 NUM_ITER = 10
 
 if __name__ == "__main__":


### PR DESCRIPTION
In #47, warmup was moved from 1800 iterations to 10 minutes. In practice, this helped significantly reduce warmup time while still erring on the side of giving engines based on just-in-time compilation enough time to properly optimize performance-sensitive code.

In #68, warmup time was decreased to 1 second. I would agree that 10 minutes was probably too conservative and makes it a annoying to do quick iterations on the benchmark, but 1 second goes too far in the opposite direction in my opinion? I'm suggesting to go with 60 seconds, which I believe would be good enough for JVM-based engines such as Lucene.