### PR TITLE
Allow overriding the benchmark query file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ export
 WIKI_SRC = "https://www.dropbox.com/s/wwnfnu441w1ec9p/wiki-articles.json.bz2"
 
 COMMANDS ?= TOP_10 TOP_100 TOP_1000 TOP_100_COUNT COUNT
+QUERIES ?= queries.txt
 
 # ENGINES ?= tantivy-0.13 lucene-8.4.0 pisa-0.8.2 rucene-0.1 bleve-0.8.0-scorch rucene-0.1 tantivy-0.11 tantivy-0.14 tantivy-0.15 tantivy-0.16 tantivy-0.17 tantivy-0.18 tantivy-0.19
 # ENGINES ?= tantivy-0.16 lucene-8.10.1 pisa-0.8.2 bleve-0.8.0-scorch bluge-0.2.2 rucene-0.1
@@ -36,7 +37,7 @@ bench:
 	@echo "--- Benchmarking ---"
 	@rm -fr results
 	@mkdir results
-	@python3 src/client.py queries.txt $(ENGINES)
+	@python3 src/client.py "$(QUERIES)" $(ENGINES)
 
 compile:
 	@echo "--- Compiling binaries ---"


### PR DESCRIPTION
## Summary
- Add `QUERIES ?= queries.txt` to preserve the default query set while allowing environment or Make overrides.
- Quote the query path passed to the benchmark client.

Example: `QUERIES=queries-union.txt WARMUP_TIME=3 make bench`

## Validation
- Checked `make -n bench` with the default, an environment override, and a Make argument containing spaces.
- `git diff --check` passed.
- No benchmarks run.