### PR TITLE
Make analyzer command optional and default to all

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,17 +128,18 @@ And open the following in your browser: [http://localhost:8080/](http://localhos
 For a quick text summary from `results.json` without opening the browser:
 
 ```
-python tools/analyze.py <engine> <command> [--filter <tag>]
+python tools/analyze.py <engine> [--command <command>] [--filter <tag>]
 ```
 
 - `<engine>` — e.g. `tantivy-main`, `tantivy-0.26`, `iresearch-26.03.1`
-- `<command>` — `TOP_100`, `TOP_100_COUNT`, or `COUNT`
+- `--command` — benchmark command such as `TOP_100`, `TOP_100_COUNT`, or `COUNT`; defaults to `all`
 - `--filter` — optional tag filter: `union`, `intersection`, or `intersection_union`
 
 Examples:
 ```
-python tools/analyze.py tantivy-main TOP_100_COUNT
-python tools/analyze.py tantivy-main TOP_100 --filter union
+python tools/analyze.py tantivy-main
+python tools/analyze.py tantivy-main --command TOP_100_COUNT
+python tools/analyze.py tantivy-main --command TOP_100 --filter union
 ```
 
 It prints query count, sample count, and avg/min/max/p50/p95/p99 latencies (in µs).

--- a/skills/bisect/SKILL.md
+++ b/skills/bisect/SKILL.md
@@ -13,5 +13,5 @@ Rebuild and bench:
 ```bash
 cd engines/<engine>/ && cargo build --release && cd -
 WARMUP_TIME=3 make bench
-python tools/analyze.py <engine> TOP_100_COUNT --filter union
+python tools/analyze.py <engine> --command TOP_100_COUNT --filter union
 ```

--- a/skills/test-changes/SKILL.md
+++ b/skills/test-changes/SKILL.md
@@ -24,5 +24,5 @@ Rebuild and bench:
 ```bash
 cd engines/<new-tantivy-engine-name>/ && cargo build --release && cd -
 WARMUP_TIME=3 make bench
-python tools/analyze.py <engine> TOP_100_COUNT --filter union
+python tools/analyze.py <engine> --command TOP_100_COUNT --filter union
 ```

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -2,10 +2,11 @@
 """Analyze and compare search-benchmark-game results.
 
 Examples:
-    python tools/analyze.py tantivy-main TOP_100_COUNT
-    python tools/analyze.py tantivy-perf TOP_100_COUNT --compare tantivy-main
-    python tools/analyze.py tantivy-perf all --compare tantivy-main --all-filters
-    python tools/analyze.py tantivy-perf all --compare tantivy-main --format tsv
+    python tools/analyze.py tantivy-main
+    python tools/analyze.py tantivy-main --command TOP_100_COUNT
+    python tools/analyze.py tantivy-perf --command TOP_100_COUNT --compare tantivy-main
+    python tools/analyze.py tantivy-perf --compare tantivy-main --all-filters
+    python tools/analyze.py tantivy-perf --compare tantivy-main --format tsv
 """
 
 import argparse
@@ -238,7 +239,9 @@ def print_tsv(rows: list[dict]) -> None:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("engine", help="candidate engine name")
-    parser.add_argument("command", help="benchmark command, or 'all'")
+    parser.add_argument(
+        "--command", default="all", help="benchmark command, or 'all' (default: all)"
+    )
     parser.add_argument(
         "--compare", "-c", metavar="ENGINE", help="baseline engine to compare against"
     )


### PR DESCRIPTION
## Summary
- Replace the positional command with optional `--command`, defaulting to `all`.
- Update analyzer, README, and skill usage examples.

```bash
python3 tools/analyze.py tantivy-perf --filter pure_union
python3 tools/analyze.py tantivy-perf --command TOP_100_COUNT --filter pure_union
```

## Testing
Verified default all-command output, explicit `--command all`, single-command selection, comparisons, and TSV output against local benchmark results.

## Dependency
Stacked on #96 to keep this diff focused. Retarget to `master` after #96 merges.